### PR TITLE
Adding lazy loading support for database entry images

### DIFF
--- a/database.html
+++ b/database.html
@@ -62,6 +62,7 @@
                 src="styles/images/Database images/image 1.jpg"
                 class="card-img-top"
                 alt="image of presentation of peter shirley"
+                loading="lazy"
               />
             </a>
             <div class="card-body text-bg-dark accordion">
@@ -121,6 +122,7 @@
                 src="styles/images/Database images/image 2.jpg"
                 class="card-img-top"
                 alt="Graph showing the quatization"
+                loading="lazy"
             /></a>
             <div class="card-body text-bg-dark accordion">
               <div class="accordion-item">
@@ -174,6 +176,7 @@
                 src="styles/images/Database images/image 3.png"
                 class="card-img-top"
                 alt="image 3"
+                loading="lazy"
             /></a>
             <div class="card-body text-bg-dark accordion">
               <div class="accordion-item">
@@ -228,6 +231,7 @@
                 src="styles/images/Database images/image 4.png"
                 class="card-img-top"
                 alt="image 4"
+                loading="lazy"
             /></a>
             <div class="card-body text-bg-dark accordion">
               <div class="accordion-item">
@@ -277,6 +281,7 @@
                 src="styles/images/Database images/image 5.png"
                 class="card-img-top"
                 alt="image 5"
+                loading="lazy"
             /></a>
             <div class="card-body text-bg-dark accordion">
               <div class="accordion-item">
@@ -333,6 +338,7 @@
                 src="styles/images/Database images/image 6.jpg"
                 class="card-img-top"
                 alt="image 6"
+                loading="lazy"
             /></a>
             <div class="card-body text-bg-dark accordion">
               <div class="accordion-item">
@@ -387,6 +393,7 @@
                 src="styles/images/Database images/image 7.jpg"
                 class="card-img-top"
                 alt="image 7"
+                loading="lazy"
             /></a>
             <div class="card-body text-bg-dark accordion">
               <div class="accordion-item">
@@ -437,6 +444,7 @@
                 src="styles/images/Database images/image 8.png"
                 class="card-img-top"
                 alt="image 8"
+                loading="lazy"
             /></a>
             <div class="card-body text-bg-dark accordion">
               <div class="accordion-item">


### PR DESCRIPTION
* added lazy loading onto the article images to ensure that only images in view are loaded

** otherwise all thousands of images are loaded, and most the user would never see